### PR TITLE
Typo and syntax fixes in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ The region format uses 2-letter codes according to [TOSEC's naming convention](h
 
 Rebuild arcade ROM sets according to the selected strategy
 
-ROM sets can be rebuild using the popular mesging strategies.
+ROM sets can be rebuilt using the popular merging strategies.
 
 Supported merging strategies:
 

--- a/README.md
+++ b/README.md
@@ -178,17 +178,17 @@ Supported DAT providers:
 
 - Redump (Download and update)
 - No-Intro (Update check only)
+<!-- -->
+    USAGE:
+        oxyromon download-dats [OPTIONS]
 
-  USAGE:
-  oxyromon download-dats [OPTIONS]
-
-  OPTIONS:
-  -a, --all Import all systems
-  -f, --force Force import of outdated DAT files
-  -h, --help Print help information
-  -n, --nointro Download No-Intro DAT files
-  -r, --redump Download Redump DAT files
-  -u, --update Check for system updates
+    OPTIONS:
+        -a, --all Import all systems
+        -f, --force Force import of outdated DAT files
+        -h, --help Print help information
+        -n, --nointro Download No-Intro DAT files
+        -r, --redump Download Redump DAT files
+        -u, --update Check for system updates
 
 ## oxyromon-import-irds
 
@@ -306,15 +306,15 @@ Supported merging strategies:
 - Non-Merged (each parent and clone set contains its ROM files and its parent's files)
 - Full Non-Merged (each parent and clone set contains its ROM files, its parent's files, and the required BIOS files)
 - ~~Merged (parent and clones are stored together, alongside the required BIOS files)~~
+<!-- -->
+    USAGE:
+        oxyromon rebuild-roms [OPTIONS]
 
-  USAGE:
-  oxyromon rebuild-roms [OPTIONS]
-
-  OPTIONS:
-  -a, --all Rebuild all arcade systems
-  -h, --help Print help information
-  -m, --merging <MERGING> Set the arcade merging strategy [possible values: SPLIT, NON_MERGED, FULL_NON_MERGED]
-  -y, --yes Automatically say yes to prompts
+    OPTIONS:
+        -a, --all Rebuild all arcade systems
+        -h, --help Print help information
+        -m, --merging <MERGING> Set the arcade merging strategy [possible values: SPLIT, NON_MERGED, FULL_NON_MERGED]
+        -y, --yes Automatically say yes to prompts
 
 ## oxyromon-convert-roms
 


### PR DESCRIPTION
- Fixed a couple of typos in the `rebuild-roms` section
- Fixed the option blocks that didn't have their syntax highlighting working correctly when they were coming directly after a list