### PR TITLE
Add building instructions for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ The CLI has no specific requirement, and you can just:
 
     cargo build --release
 
+For Windows, asm-hashes don't work with MSVC toolchain at the moment so you need to build without it:
+
+    cargo build --release --no-default-features --features use-rustls
+    
+You can also target GNU to solve the asm-hashes issue:
+
+    cargo build --release --target x86_64-pc-windows-gnu
+
 For the web UI, you will also need yarn:
 
     cargo build --release --features server


### PR DESCRIPTION
Rust can't build asm-hashes with MSVC at the moment --->https://github.com/RustCrypto/asm-hashes/issues/17

- cargo build --release --target x86_64-pc-windows-gnu

Of course you have to add MSYS2-mingw-w64 to the variable PATH to use gcc.exe

You can also build it without asm-hashes : 

- cargo build --release --no-default-features --features use-rustls

Closes https://github.com/alucryd/oxyromon/issues/151