### PR TITLE
Add "empty" option to purge-systems

### DIFF
--- a/.sqlx/query-2c3f7d6a69b5e844a236d9826dee7a2d8fbad9753296e734d2fac6b3d883acd9.json
+++ b/.sqlx/query-2c3f7d6a69b5e844a236d9826dee7a2d8fbad9753296e734d2fac6b3d883acd9.json
@@ -1,0 +1,68 @@
+{
+  "db_name": "SQLite",
+  "query": "\n        SELECT *\n        FROM systems\n        WHERE systems.completion = 0\n        AND NOT EXISTS (\n            SELECT 1 \n            FROM games \n            WHERE systems.id = games.system_id \n            AND games.completion != 0)\n        ORDER BY systems.name\n        ",
+  "describe": {
+    "columns": [
+      {
+        "name": "id",
+        "ordinal": 0,
+        "type_info": "Integer"
+      },
+      {
+        "name": "name",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "description",
+        "ordinal": 2,
+        "type_info": "Text"
+      },
+      {
+        "name": "version",
+        "ordinal": 3,
+        "type_info": "Text"
+      },
+      {
+        "name": "url",
+        "ordinal": 4,
+        "type_info": "Text"
+      },
+      {
+        "name": "arcade",
+        "ordinal": 5,
+        "type_info": "Bool"
+      },
+      {
+        "name": "merging",
+        "ordinal": 6,
+        "type_info": "Integer"
+      },
+      {
+        "name": "custom_name",
+        "ordinal": 7,
+        "type_info": "Text"
+      },
+      {
+        "name": "completion",
+        "ordinal": 8,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 0
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "2c3f7d6a69b5e844a236d9826dee7a2d8fbad9753296e734d2fac6b3d883acd9"
+}

--- a/src/check_roms.rs
+++ b/src/check_roms.rs
@@ -55,7 +55,7 @@ pub async fn main(
     matches: &ArgMatches,
     progress_bar: &ProgressBar,
 ) -> SimpleResult<()> {
-    let systems = prompt_for_systems(connection, None, false, matches.get_flag("ALL")).await?;
+    let systems = prompt_for_systems(connection, None, false, false, matches.get_flag("ALL")).await?;
     for system in systems {
         progress_bar.println(format!("Processing \"{}\"", system.name));
         let games = match matches.get_many::<String>("GAME") {

--- a/src/convert_roms.rs
+++ b/src/convert_roms.rs
@@ -114,7 +114,7 @@ pub async fn main(
             systems.dedup_by_key(|system| system.id);
             systems
         }
-        None => prompt_for_systems(connection, None, false, matches.get_flag("ALL")).await?,
+        None => prompt_for_systems(connection, None, false, false, matches.get_flag("ALL")).await?,
     };
     let format = match matches.get_one::<String>("FORMAT") {
         Some(format) => format.as_str().to_owned(),

--- a/src/database.rs
+++ b/src/database.rs
@@ -231,6 +231,26 @@ pub async fn find_arcade_systems(connection: &mut SqliteConnection) -> Vec<Syste
     .expect("Error while finding arcade systems")
 }
 
+pub async fn find_empty_systems(connection: &mut SqliteConnection) -> Vec<System> {
+    sqlx::query_as!(
+        System,
+        "
+        SELECT *
+        FROM systems
+        WHERE systems.completion = 0
+        AND NOT EXISTS (
+            SELECT 1 
+            FROM games 
+            WHERE systems.id = games.system_id 
+            AND games.completion != 0)
+        ORDER BY systems.name
+        ",
+    )
+    .fetch_all(connection)
+    .await
+    .expect("Error while finding empty systems")
+}
+
 pub async fn find_systems_by_url(connection: &mut SqliteConnection, url: &str) -> Vec<System> {
     sqlx::query_as!(
         System,

--- a/src/download_dats.rs
+++ b/src/download_dats.rs
@@ -189,7 +189,7 @@ async fn update_nointro_dats(
     {
         let profile: ProfileXml =
             try_with!(de::from_str(&response), "Failed to parse No-Intro profiles");
-        let systems = prompt_for_systems(connection, Some(NOINTRO_SYSTEM_URL), false, all).await?;
+        let systems = prompt_for_systems(connection, Some(NOINTRO_SYSTEM_URL), false, false, all).await?;
         for system in systems {
             progress_bar.println(format!("Processing \"{}\"", &system.name));
             let system_xml = profile
@@ -250,7 +250,7 @@ async fn update_redump_dats(
     all: bool,
     force: bool,
 ) -> SimpleResult<()> {
-    let systems = prompt_for_systems(connection, Some(REDUMP_SYSTEM_URL), false, all).await?;
+    let systems = prompt_for_systems(connection, Some(REDUMP_SYSTEM_URL), false, false, all).await?;
     for system in systems {
         download_redump_dat(connection, progress_bar, base_url, &system.name, force).await?;
     }

--- a/src/export_roms.rs
+++ b/src/export_roms.rs
@@ -96,7 +96,7 @@ pub async fn main(
             systems.dedup_by_key(|system| system.id);
             systems
         }
-        None => prompt_for_systems(connection, None, false, false).await?,
+        None => prompt_for_systems(connection, None, false, false, false).await?,
     };
     let format = match matches.get_one::<String>("FORMAT") {
         Some(format) => format.as_str().to_owned(),

--- a/src/generate_playlists.rs
+++ b/src/generate_playlists.rs
@@ -43,6 +43,7 @@ pub async fn main(
         connection,
         Some(REDUMP_SYSTEM_URL),
         false,
+        false,
         matches.get_flag("ALL"),
     )
     .await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,7 +276,12 @@ async fn main() -> SimpleResult<()> {
                 .await?
             }
             Some("purge-systems") => {
-                purge_systems::main(&mut pool.acquire().await.unwrap(), &progress_bar).await?
+                purge_systems::main(
+                    &mut pool.acquire().await.unwrap(),
+                    matches.subcommand_matches("purge-systems").unwrap(),
+                    &progress_bar,
+                )
+                .await?
             }
             Some("generate-playlists") => {
                 generate_playlists::main(

--- a/src/prompt.rs
+++ b/src/prompt.rs
@@ -10,10 +10,13 @@ pub async fn prompt_for_systems(
     connection: &mut SqliteConnection,
     url: Option<&str>,
     arcade_only: bool,
+    empty_only: bool,
     all: bool,
 ) -> SimpleResult<Vec<System>> {
     let systems = if arcade_only {
         find_arcade_systems(connection).await
+    } else if empty_only {
+        find_empty_systems(connection).await
     } else {
         match url {
             Some(url) => find_systems_by_url(connection, url).await,

--- a/src/purge_systems.rs
+++ b/src/purge_systems.rs
@@ -4,21 +4,31 @@ use super::model::*;
 use super::prompt::*;
 use super::util::*;
 use super::SimpleResult;
-use clap::Command;
+use clap::{Arg, ArgAction, ArgMatches, Command};
 use indicatif::ProgressBar;
 use sqlx::sqlite::SqliteConnection;
 use std::path::Path;
 use std::time::Duration;
 
 pub fn subcommand() -> Command {
-    Command::new("purge-systems").about("Purge systems")
+    Command::new("purge-systems")
+        .about("Purge systems")
+        .arg(
+            Arg::new("EMPTY")
+                .short('e')
+                .long("empty")
+                .help("Only list empty systems for selection")
+                .required(false)
+                .action(ArgAction::SetTrue),
+        )
 }
 
 pub async fn main(
     connection: &mut SqliteConnection,
+    matches: &ArgMatches,
     progress_bar: &ProgressBar,
 ) -> SimpleResult<()> {
-    let systems = prompt_for_systems(connection, None, false, false).await?;
+    let systems = prompt_for_systems(connection, None, false, matches.get_flag("EMPTY"), false).await?;
     progress_bar.enable_steady_tick(Duration::from_millis(100));
     for system in systems {
         purge_system(connection, progress_bar, &system).await?;

--- a/src/rebuild_roms.rs
+++ b/src/rebuild_roms.rs
@@ -63,7 +63,7 @@ pub async fn main(
     matches: &ArgMatches,
     progress_bar: &ProgressBar,
 ) -> SimpleResult<()> {
-    let systems = prompt_for_systems(connection, None, true, matches.get_flag("ALL")).await?;
+    let systems = prompt_for_systems(connection, None, true, false, matches.get_flag("ALL")).await?;
 
     let merging = match matches.get_one::<String>("MERGING").map(String::as_str) {
         Some("SPLIT") => Merging::Split,

--- a/src/sort_roms.rs
+++ b/src/sort_roms.rs
@@ -95,7 +95,7 @@ pub async fn main(
     matches: &ArgMatches,
     progress_bar: &ProgressBar,
 ) -> SimpleResult<()> {
-    let systems = prompt_for_systems(connection, None, false, matches.get_flag("ALL")).await?;
+    let systems = prompt_for_systems(connection, None, false, false, matches.get_flag("ALL")).await?;
 
     let all_regions = get_regions(connection, matches, "REGIONS_ALL").await;
     let one_regions = get_regions(connection, matches, "REGIONS_ONE").await;


### PR DESCRIPTION
Hi,
I've added a feature for my use case; purging multiple "empty" systems' datsets in bulk. I previously imported datsets without checking which systems were wanted.
I've added an "-e" option to purge-systems which filters empty systems with completion=0 for selection. All roms belonging to the system must also have completion=0.
To do so I added a fifth argument to prompt_for_systems(), not sure if this is the preferred implementation.